### PR TITLE
chore: add web LogoSVG and lazy-load it

### DIFF
--- a/src/LogoSVG/index.web.tsx
+++ b/src/LogoSVG/index.web.tsx
@@ -1,0 +1,25 @@
+import { SvgUri, SvgXml } from 'react-native-svg';
+import type { LogoSVGProps } from './types';
+
+const isString = (variable: unknown): variable is string => {
+  return typeof variable === 'string';
+};
+
+const isUrlString = (variable: unknown): boolean => {
+  return isString(variable) && variable.startsWith('http');
+};
+
+const LogoSVG = ({ svg, logoSize, logoColor }: LogoSVGProps) => {
+  if (isString(svg)) {
+    if (isUrlString(svg)) {
+      return <SvgUri uri={svg} fill={logoColor} width={logoSize} height={logoSize} />;
+    }
+
+    return <SvgXml xml={svg} fill={logoColor} width={logoSize} height={logoSize} />;
+  }
+
+  // Local assets via require() are not supported on web
+  return null;
+};
+
+export default LogoSVG;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,9 +1,10 @@
-import { useMemo } from 'react';
+import { Suspense, lazy, useMemo } from 'react';
 import Svg, { ClipPath, Defs, G, Image, LinearGradient, Path, Rect, Stop } from 'react-native-svg';
-import LogoSVG from './LogoSVG';
 import { genMatrix } from './genMatrix';
 import { transformMatrixIntoPath } from './transformMatrixIntoPath';
 import type { QRCodeProps, RenderLogoProps } from './types';
+
+const LazyLogoSVG = lazy(() => import('./LogoSVG'));
 
 const renderLogo = ({
   size,
@@ -50,7 +51,9 @@ const renderLogo = ({
           fill={logoBackgroundColor}
         />
         {logoSVG ? (
-          <LogoSVG svg={logoSVG} logoSize={logoSize} logoColor={logoColor} />
+          <Suspense fallback={null}>
+            <LazyLogoSVG svg={logoSVG} logoSize={logoSize} logoColor={logoColor} />
+          </Suspense>
         ) : (
           <Image
             width={logoSize}


### PR DESCRIPTION
This pull request refactors how SVG logos are rendered in the web version of the project. The main improvements include implementing lazy loading for the `LogoSVG` component and enhancing the logic for handling SVG sources. These changes optimize performance and improve maintainability.

**SVG Logo Rendering Improvements:**

* Introduced a new `LogoSVG` component in `src/LogoSVG/index.web.tsx` that determines whether to render an SVG from a URL or from XML, and returns `null` for unsupported local assets.
* Enhanced the logic in `LogoSVG` to distinguish between SVG sources (URL vs. XML string) and render them appropriately using `SvgUri` or `SvgXml`.

**Performance Optimization:**

* Updated `src/index.tsx` to use React's `lazy` and `Suspense` for loading the `LogoSVG` component asynchronously, reducing the initial bundle size and improving load times. [[1]](diffhunk://#diff-0b5adbfe7b36e4ae2f479291e20152e33e940f7f265162d77f40f6bdb5da7405L1-R8) [[2]](diffhunk://#diff-0b5adbfe7b36e4ae2f479291e20152e33e940f7f265162d77f40f6bdb5da7405L53-R56)