### PR TITLE
Pfr 5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-svg-qrcode",
-  "version": "1.1.12",
+  "version": "1.1.13",
   "description": "A minimal dependency pure JS QR Code generator for React Native",
   "repository": {
     "type": "git",

--- a/src/LogoSVG/index.tsx
+++ b/src/LogoSVG/index.tsx
@@ -1,3 +1,4 @@
+import { cloneElement } from 'react';
 import { SvgUri, SvgXml } from 'react-native-svg';
 import { LocalSvg } from 'react-native-svg/css';
 import type { LogoSVGProps } from './types';
@@ -19,7 +20,15 @@ const LogoSVG = ({ svg, logoSize, logoColor }: LogoSVGProps) => {
     return <SvgXml xml={svg} fill={logoColor} width={logoSize} height={logoSize} />;
   }
 
-  return <LocalSvg asset={svg} fill={logoColor} width={logoSize} height={logoSize} />;
+  if (typeof svg === 'number') {
+    return <LocalSvg asset={svg} fill={logoColor} width={logoSize} height={logoSize} />;
+  }
+
+  return cloneElement(svg, {
+    width: logoSize,
+    height: logoSize,
+    ...(logoColor ? { fill: logoColor } : {}),
+  });
 };
 
 export default LogoSVG;

--- a/src/LogoSVG/index.web.tsx
+++ b/src/LogoSVG/index.web.tsx
@@ -1,3 +1,4 @@
+import { cloneElement } from 'react';
 import { SvgUri, SvgXml } from 'react-native-svg';
 import type { LogoSVGProps } from './types';
 
@@ -18,8 +19,16 @@ const LogoSVG = ({ svg, logoSize, logoColor }: LogoSVGProps) => {
     return <SvgXml xml={svg} fill={logoColor} width={logoSize} height={logoSize} />;
   }
 
-  // Local assets via require() are not supported on web
-  return null;
+  if (typeof svg === 'number') {
+    // Local assets via require() are not supported on web
+    return null;
+  }
+
+  return cloneElement(svg, {
+    width: logoSize,
+    height: logoSize,
+    ...(logoColor ? { fill: logoColor } : {}),
+  });
 };
 
 export default LogoSVG;

--- a/src/LogoSVG/index.web.tsx
+++ b/src/LogoSVG/index.web.tsx
@@ -1,0 +1,25 @@
+import { SvgUri, SvgXml } from 'react-native-svg';
+import type { LogoSVGProps } from './types';
+
+const isString = (variable: unknown): variable is string => {
+  return typeof variable === 'string';
+};
+
+const isUrlString = (variable: unknown): boolean => {
+  return isString(variable) && variable.startsWith('http');
+};
+
+const LogoSVG = ({ svg, logoSize, logoColor }: LogoSVGProps) => {
+  if (isString(svg)) {
+    if (isUrlString(svg)) {
+      return <SvgUri uri={svg} fill={logoColor} width={logoSize} height={logoSize} />;
+    }
+
+    return <SvgXml xml={svg} fill={logoColor} width={logoSize} height={logoSize} />;
+  }
+
+  // Local assets via require() are not supported on web
+  return null;
+};
+
+export default LogoSVG;

--- a/src/LogoSVG/types.ts
+++ b/src/LogoSVG/types.ts
@@ -1,5 +1,7 @@
+import type { ReactElement } from 'react';
+
 export interface LogoSVGProps {
-  svg: string | number;
+  svg: string | number | ReactElement;
   logoSize: number;
   logoColor?: string;
 }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,9 +1,10 @@
-import { useMemo } from 'react';
+import { Suspense, lazy, useMemo } from 'react';
 import Svg, { ClipPath, Defs, G, Image, LinearGradient, Path, Rect, Stop } from 'react-native-svg';
-import LogoSVG from './LogoSVG';
 import { genMatrix } from './genMatrix';
 import { transformMatrixIntoPath } from './transformMatrixIntoPath';
 import type { QRCodeProps, RenderLogoProps } from './types';
+
+const LazyLogoSVG = lazy(() => import('./LogoSVG'));
 
 const renderLogo = ({
   size,
@@ -50,7 +51,9 @@ const renderLogo = ({
           fill={logoBackgroundColor}
         />
         {logoSVG ? (
-          <LogoSVG svg={logoSVG} logoSize={logoSize} logoColor={logoColor} />
+          <Suspense fallback={null}>
+            <LazyLogoSVG svg={logoSVG} logoSize={logoSize} logoColor={logoColor} />
+          </Suspense>
         ) : (
           <Image
             width={logoSize}

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,10 +1,12 @@
+import type { ReactElement } from 'react';
+
 export interface QRCodeProps {
   value?: string;
   size?: number;
   color?: string;
   backgroundColor?: string;
   logo?: string;
-  logoSVG?: string | number;
+  logoSVG?: string | number | ReactElement;
   logoSize?: number;
   logoBackgroundColor?: string;
   logoColor?: string;
@@ -23,7 +25,7 @@ export interface RenderLogoProps {
   size: number;
   backgroundColor: string;
   logo?: string;
-  logoSVG?: string | number;
+  logoSVG?: string | number | ReactElement;
   logoSize: number;
   logoBackgroundColor: string;
   logoColor?: string;


### PR DESCRIPTION
This pull request extends the flexibility of the QR code logo rendering by allowing a React element to be passed as the `logoSVG` prop in addition to the previously supported string or number types. The change is implemented across both the main and web-specific versions of the `LogoSVG` component, and relevant type definitions are updated accordingly.

**Component enhancements:**

* Updated `LogoSVG` in both `index.tsx` and `index.web.tsx` to support rendering a React element as the `svg` prop, using `cloneElement` to inject sizing and color props. (`[[1]](diffhunk://#diff-1c2250f9aa4fe293f0d30f45a51dc1e93c3e686f38f443b54deadbc999c800deR1)`, `[[2]](diffhunk://#diff-1c2250f9aa4fe293f0d30f45a51dc1e93c3e686f38f443b54deadbc999c800deR23-R31)`, `[[3]](diffhunk://#diff-2aad8dfa8465ac7c30d79b7a411c6a2c26749cae61b396ed18691b2c2b36fe7bR1)`, `[[4]](diffhunk://#diff-2aad8dfa8465ac7c30d79b7a411c6a2c26749cae61b396ed18691b2c2b36fe7bR22-R31)`)

**Type system updates:**

* Extended the `LogoSVGProps`, `QRCodeProps`, and `RenderLogoProps` interfaces to accept a `ReactElement` for the `svg`/`logoSVG` props, ensuring type safety and consistency throughout the codebase. (`[[1]](diffhunk://#diff-12f9e0a55a19f6bb3cd52e2522f486ca3c42d43d54c91e807ea3fe05e03c6114R1-R4)`, `[[2]](diffhunk://#diff-c54113cf61ec99691748a3890bfbeb00e10efb3f0a76f03a0fd9ec49072e410aR1-R9)`, `[[3]](diffhunk://#diff-c54113cf61ec99691748a3890bfbeb00e10efb3f0a76f03a0fd9ec49072e410aL26-R28)`)

**Versioning:**

* Bumped the package version to `1.1.13` in `package.json` to reflect the new feature. (`[package.jsonL3-R3](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3)`)